### PR TITLE
[Feature] Refer to the English version (PDF) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # 个人简介
+[For English (Personal Statement, PDF format)](./ShiBochenAcademicMisconduct.pdf)
+
 大家好，我是施b辰，博士，清华大学“水木学者”，国家级人才计划青年拔尖人才（**29岁获得，中国历史上最年轻**），于清华大学电机工程与应用电子技术系获得学士和博士学位。主要研究方向为电力电子混杂系统动力学表征、多尺度建模仿真及其工业软件。详细介绍可以在[此处](http://www.eiri.tsinghua.edu.cn/yjry/All/e0b2e2d285e246bd9f56f047be9af30d.htm)找到。视频介绍可以在[这里](https://vimeo.com/946340773?share=copy)找到，本教程的电子版pdf可通过https://github.com/ShiArthur03 找到。
 ## 学术成就
 **主持**国家重点研发计划“电机装备与系统多时间尺度工业仿真软件”2023YFB3307000（**清华大学首位博士后主持**）、国家自然科学基金青年基金、中国博士后科学基金2022M721776等项目，参与国家自然科学基金重大项目、联合重点项目、“十三五”国家重点研发计划“智能电网技术与装备”重点专项等。发表SCI/EI论文40余篇（其中代表性著作见 [Publication](https://github.com/ShiArthur03/ShiArthur03/tree/main/06_Publication)），获授权中国发明专利10余项、美国发明专利2项。担任IEEE电力电子学会（PELS）中国区会员委员会秘书长、会员发展工作委员会委员、IEEE SYPS等多个国际学术会议技术委员会主席、组织委员会主席、分会场主席等。


### PR DESCRIPTION
Currently some visitors (including me) fail to find an English version at their first glance, while actually there's just one lying under this very repo. 

This commit adds a reference to this bundled English version (a PDF file) at the beginning of README.

